### PR TITLE
Avoid warning & Do not regmap_exit & set Reset GPIO to output-high

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ GPIO expander example with gpio-keys:
 		#gpio-cells = <2>;
 		interrupt-controller;
 		#interrupt-cells = <2>;
+		reset-gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
 
 		pinctrl-names = "default";
 		pinctrl-0 = <&keys_int>;
@@ -119,6 +120,7 @@ Pure LED class example:
 	key_backlight: gpio@5b {
 		compatible = "awinic,aw9523b";
 		reg = <0x5b>;
+		reset-gpios = <&gpio 21 GPIO_ACTIVE_HIGH>;
 
 		status = "okay";
 

--- a/src/gpio-aw9523.c
+++ b/src/gpio-aw9523.c
@@ -22,6 +22,7 @@
 #include <linux/module.h>
 #include <linux/of.h>
 #include <linux/of_device.h>
+#include <linux/of_gpio.h>
 #include <linux/regmap.h>
 #include <linux/slab.h>
 #include <linux/workqueue.h>
@@ -745,6 +746,11 @@ static int aw9523_probe(struct i2c_client *	    client,
 	}
 
 	i2c_set_clientdata(client, aw);
+
+	aw->reset_gpio = devm_gpiod_get(aw->dev, "reset", GPIOD_OUT_HIGH);
+	if (IS_ERR(aw->reset_gpio))
+		return PTR_ERR(aw->reset_gpio);
+	gpiod_set_consumer_name(aw->reset_gpio, "aw9523b-reset");
 
 	aw->chip.label	= AW_DRV_NAME;
 	aw->chip.parent = aw->dev;

--- a/src/gpio-aw9523.c
+++ b/src/gpio-aw9523.c
@@ -863,8 +863,6 @@ fail:
 	devm_gpiochip_remove(aw->dev, &aw->chip);
 
 fail_pre_gpiochip:
-	regmap_exit(aw->regmap);
-
 	mutex_destroy(&aw->lock);
 	aw9523_led_free_resources(aw);
 
@@ -893,11 +891,6 @@ static int aw9523_remove(struct i2c_client *client)
 
 	AW_DEBUG(&client->dev, "%s: devm_gpiochip_remove...\n", __func__);
 	devm_gpiochip_remove(&client->dev, &aw->chip);
-
-	/* FIXME regmap_exit leads to a NULL pointer after returning from this function! 
-	AW_DEBUG(&client->dev, "%s: regmap_exit...\n", __func__);
-	regmap_exit(aw->regmap);
-	*/
 
 	AW_DEBUG(&client->dev, "%s: mutex_destroy...\n", __func__);
 	mutex_destroy(&aw->lock);

--- a/src/gpio-aw9523.h
+++ b/src/gpio-aw9523.h
@@ -155,6 +155,7 @@ struct aw9523b {
 	unsigned	status; /* current status */
 	unsigned int	irq_parent;
 	unsigned	irq_enabled; /* enabled irqs */
+	struct gpio_desc *reset_gpio;
 
 	struct aw9523b_led *led_data; /* optional LED feature */
 };


### PR DESCRIPTION
Hi, thanks for your great work. It helps me a lot.

Here is some cases I'd like to talk.

## Avoid C89 warnings

Probably because of Android's strict compilation rules, any warnings from drivers are converted to errors and interrupt the compilation. The following are the warnings I solved:

1. Mixed declarations and code
2. GCC(C89) doesn't allow variable declarations in for loop initializers
3. If we closed AWINIC_DEBUG, the variable `aw` at `aw9523_gpio_set_config` will not be used

## Do not use `regmap_exit`

Because the regmap was initialized by `devm_regmap_init_i2c`, its lifetime will be managered by device.

If the driver failed to probe, and go to `fail_pre_gpiochip` then used `regmap_exit` free the regmap, the crash will ocurred. Here is the crash trace:

```text
    13.601392:   <2> Call trace:
    13.603928:   <2>  kfree+0x194/0x930
    13.607102:   <2>  regcache_exit+0x2c/0x98
    13.610807:   <2>  regmap_exit+0x20/0x118
    13.614423:   <2>  devm_regmap_release+0x1c/0x28
    13.618654:   <2>  release_nodes+0x21c/0x280
    13.622533:   <2>  devres_release_all+0x3c/0x60
    13.626673:   <2>  really_probe+0x288/0x6d8
    13.630464:   <2>  driver_probe_device+0x74/0x148
    13.634782:   <2>  __device_attach_driver+0x134/0x1d8
    13.639459:   <2>  bus_for_each_drv+0x88/0xd0
    13.643421:   <2>  __device_attach+0xc4/0x190
    13.647383:   <2>  device_initial_probe+0x20/0x30
    13.651699:   <2>  bus_probe_device+0x34/0xa0
    13.655661:   <2>  device_add+0x748/0x8a8
    13.659275:   <2>  device_register+0x24/0x30
    13.663158:   <2>  i2c_new_device+0x308/0x368
    13.667121:   <2>  of_i2c_register_devices+0x114/0x1c8
    13.671887:   <2>  i2c_register_adapter+0x218/0x3e8
    13.676382:   <2>  i2c_add_adapter+0xec/0x118
    13.680344:   <2>  geni_i2c_probe+0x5bc/0x618
    13.684305:   <2>  platform_drv_probe+0x80/0xb8
    13.688444:   <2>  really_probe+0x4ec/0x6d8
    13.692235:   <2>  driver_probe_device+0x74/0x148
    13.696552:   <2>  __driver_attach+0x128/0x1e0
    13.700602:   <2>  bus_for_each_dev+0x84/0xd0
    13.704563:   <2>  driver_attach+0x2c/0x38
    13.708264:   <2>  bus_add_driver+0x144/0x268
    13.712224:   <2>  driver_register+0x78/0x110
    13.716185:   <2>  __platform_driver_register+0x4c/0x58
    13.721045:   <2>  geni_i2c_driver_init+0x1c/0x24
    13.725363:   <2>  do_one_initcall+0x1fc/0x410
    13.729416:   <2>  kernel_init_freeable+0x4b4/0x568
    13.733917:   <2>  kernel_init+0x18/0x298
    13.737530:   <2>  ret_from_fork+0x10/0x1c
    13.741234:   <6> Code: f2ffffe9 aa090109 d2dff7ea f2ffffea (f9400129) 
    13.747512:   <6> ---[ end trace 661c305ebda847e0 ]---
```

We can see that the `regmap_exit` was called by `devm_regmap_release`, and `devm_regmap_release` will be automatically called when device was released, since we used `devm_regmap_init_i2c` to initialize the regmap. Because we have freed it before, so it faild to free the regmap again.

## Set reset GPIO to output-high

The AW9523B chip need to set the reset GPIO (RSTN) to output-high to work properly. I suggest to integrate it in the driver because most of drivers do this.
